### PR TITLE
Card search will now attempt to match search string exactly.

### DIFF
--- a/mtg_bot.js
+++ b/mtg_bot.js
@@ -5,67 +5,104 @@ fs.readFile(process.argv[2], 'utf8', function (err,bot_token) {
 	if (err) {
 		return console.log(err);
 	}
+
 	const mtg = require('mtgsdk');
 
 	var rtm = new RtmClient(bot_token.trim());
+	
+	console.log('Ready');
 
 	rtm.on(RTM_EVENTS.MESSAGE, function handleRtmMessage(message) {
 		if(message.type == 'message' && message.hasOwnProperty('text'))
 		{
-			if ((matches = message.text.match(/\[\[[\w ,\-']+\]\]/gi)) != null)
+			//Matches any MtG card name between [[brackets]]
+			if ((matches = message.text.match(/\[\[[\w ,.!?:\-\(\)']+\]\]/gi)) != null)
 			{
 				for (var f = 0, matchesLen = matches.length; f < matchesLen; f++)
 				{
 					var left = matches[f].search("\\[\\[") + 2;
 					var right = matches[f].search("\\]\\]");
-					var res = matches[f].slice(left, right);
+					var searchString = matches[f].slice(left, right).trim();
 
-					if (res.indexOf("//") > 0)
-					{
-						res = "\"" + res.slice(0, res.indexOf("//")).trim() + "\"";
-					}	
+					// Lord only knows what this line does.
+					searchString = searchString.replace("’", "%27");
 
-					res = res.replace("’", "%27");
+					var quotedString = "\"" + searchString + "\"";
 
-					if(res == "Slambo" || res == "slambo")
+					// Returns the glorious portrait of Zac "Slambo" Hodgkin, when [[Slambo]] is in the message.
+					if(searchString == "Slambo" || searchString == "slambo")
 					{
 						var t = Date.now();
 						console.log(t);
 
-						if(t % 2 == 0)
+						switch(t % 3)
 						{
-							url = "http://i.imgur.com/4vFIe9d.jpg";
-						}
-						else
-						{
-							url = "http://i.imgur.com/kZyW3EP.png";
+							case 0:  url = "http://i.imgur.com/4vFIe9d.jpg"; break;
+							case 1:  url = "http://i.imgur.com/kZyW3EP.png"; break;
+							case 2:  url = "http://i.imgur.com/ytr7eNB.png"; break;
+							default: url = "https://ca.slack-edge.com/T50SNSNF6-U51KKUB0W-480e24985283-512"
 						}
 
 						rtm.sendMessage(url, message.channel);
+						return;
 					}
 
-					mtg.card.where({name: res}).then(
+					// Coolghav finger-guns. [[Zoop]]
+					if (searchString == "Zoop" || searchString == "zoop")
+					{
+						rtm.sendMessage(":coolghav:\n:point_right::point_right:", message.channel);
+						return;
+					}
+
+					// Selects all cards from the database that match the search string exactly
+					mtg.card.where({name: quotedString, contains: 'imageUrl'}).then(
 						function(cards)
 						{
-							if (typeof cards != 'undefined')
+							if (typeof cards == 'undefined')
 							{
-								for (var i = 0, len = cards.length; i < len; i++)
-								{
-									console.log(cards[i].name);
-									if (typeof cards[i].imageUrl != 'undefined' && cards[i].set != 'VAN')
+								return;
+							}
+
+							if (cards.length > 0)
+							{
+								// If there are multiple matching cards, they are different printings. We don't care, so return the first one.
+								rtm.sendMessage(cards[0].imageUrl, message.channel)
+							}
+							else
+							{
+								// If there are no strict matches, select all cards that at least contain the search string.
+								mtg.card.where({name: searchString, contains: 'imageUrl'}).then(
+									function(cards, url)
 									{
-										rtm.sendMessage(cards[i].imageUrl, message.channel);
-										break;
+										if (typeof cards != 'undefined')
+										{
+											// We currently have no way of determining what card the user actually wants in this case. So just pick one...
+											for (var i = 0, len = cards.length; i < len; i++)
+											{
+												// As long as it isn't from Vanguard, apparently. This should probably check for card types.
+												if (cards[i].set != 'VAN')
+												{
+													rtm.sendMessage(cards[i].imageUrl, message.channel);
+													return;
+												}
+											}
+										}
 									}
-								}
+								);
 							}
 						}
 					);
 				}
-			}
+			} 
 			else if (message.text.match(/i'?m bored/gi) != null)
 			{
-				rtm.sendMessage("Hi Bored!  I'm mtgbot!", message.channel);
+				//Hi mtgbot! I'm bored!
+				rtm.sendMessage("Hi Bored! I'm mtgbot!", message.channel);
+			}
+			else if (message.text.match(/launch[\w '-,]*\?/gi) != null)
+			{
+				//Screw you and your lunch plans.
+				rtm.sendMessage(":rocket:", message.channel);
 			}
 		}
 	});

--- a/mtg_bot.js
+++ b/mtg_bot.js
@@ -39,7 +39,7 @@ fs.readFile(process.argv[2], 'utf8', function (err,bot_token) {
 						{
 							case 0:  url = "http://i.imgur.com/4vFIe9d.jpg"; break;
 							case 1:  url = "http://i.imgur.com/kZyW3EP.png"; break;
-							case 2:  url = "http://i.imgur.com/ytr7eNB.png"; break;
+							case 2:  url = "https://i.imgur.com/WcpiftW.png"; break;
 							default: url = "https://ca.slack-edge.com/T50SNSNF6-U51KKUB0W-480e24985283-512"
 						}
 

--- a/mtg_bot.js
+++ b/mtg_bot.js
@@ -16,7 +16,7 @@ fs.readFile(process.argv[2], 'utf8', function (err,bot_token) {
 		if(message.type == 'message' && message.hasOwnProperty('text'))
 		{
 			//Matches any MtG card name between [[brackets]]
-			if ((matches = message.text.match(/\[\[[\w ,.!?:\-\(\)']+\]\]/gi)) != null)
+			if ((matches = message.text.match(/\[\[[\w ,.!?:\-\(\)\/']+\]\]/gi)) != null)
 			{
 				for (var f = 0, matchesLen = matches.length; f < matchesLen; f++)
 				{
@@ -76,15 +76,34 @@ fs.readFile(process.argv[2], 'utf8', function (err,bot_token) {
 									{
 										if (typeof cards != 'undefined')
 										{
+											var foundACard = -1;
+
 											// We currently have no way of determining what card the user actually wants in this case. So just pick one...
 											for (var i = 0, len = cards.length; i < len; i++)
 											{
+												console.log(cards[i].name + "  -  " + cards[i].supertypes + "  -  " + cards[i].types + "  -  " + cards[i].set + "  -  " + cards[i].imageUrl)
+												
 												// As long as it isn't from Vanguard, apparently. This should probably check for card types.
-												if (cards[i].set != 'VAN')
+												// I'm now also making it exclude masterpieces, since those tend to be hard to read cough cough invocations.
+												if (cards[i].set != 'VAN' && !cards[i].set.includes('MPS'))
 												{
-													rtm.sendMessage(cards[i].imageUrl, message.channel);
-													return;
+													// The algorithm biases towards Legendaries, because those are more likely to be what the user is referring to. 
+													// Especially when they just use the proper name, without a descriptor. This will need refinement.
+													if (cards[i].supertypes == 'Legendary')
+													{
+														rtm.sendMessage(cards[i].imageUrl, message.channel);
+														return;
+													}
+													else if (foundACard == -1)
+													{
+														foundACard = i;
+													}
 												}
+											}
+
+											if (foundACard != -1)
+											{
+												rtm.sendMessage(cards[foundACard].imageUrl, message.channel);
 											}
 										}
 									}


### PR DESCRIPTION
The card search feature will now try to find a card whose name matches exactly. If that fails, it will do the normal search (first card whose name contains the search string.

Also, the [[ ]] regex now matches _all_ of the possible characters that exist in mtg card names (a few were missing, but those were mostly from Un-cards, Circles of Protection, or _Sarpadian Empires, Vol. VIII_.

I added a couple other little things too.